### PR TITLE
docs(material/autocomplete): fix incorrect tab title for autocomplete…

### DIFF
--- a/esm2020/example-module.mjs
+++ b/esm2020/example-module.mjs
@@ -1261,7 +1261,7 @@ export const EXAMPLE_COMPONENTS = {
         "componentName": "AutocompleteOptgroupExample",
         "files": [
             "autocomplete-optgroup-example.ts",
-            "./autocomplete-optgroup-example.html"
+            "autocomplete-optgroup-example.html"
         ],
         "selector": "autocomplete-optgroup-example",
         "additionalComponents": [],

--- a/fesm2015/components-examples.mjs
+++ b/fesm2015/components-examples.mjs
@@ -1261,7 +1261,7 @@ const EXAMPLE_COMPONENTS = {
         "componentName": "AutocompleteOptgroupExample",
         "files": [
             "autocomplete-optgroup-example.ts",
-            "./autocomplete-optgroup-example.html"
+            "autocomplete-optgroup-example.html"
         ],
         "selector": "autocomplete-optgroup-example",
         "additionalComponents": [],

--- a/fesm2020/components-examples.mjs
+++ b/fesm2020/components-examples.mjs
@@ -1261,7 +1261,7 @@ const EXAMPLE_COMPONENTS = {
         "componentName": "AutocompleteOptgroupExample",
         "files": [
             "autocomplete-optgroup-example.ts",
-            "./autocomplete-optgroup-example.html"
+            "autocomplete-optgroup-example.html"
         ],
         "selector": "autocomplete-optgroup-example",
         "additionalComponents": [],


### PR DESCRIPTION

Correct the tab title for autocomplete optgroup example code.

Fixes #24604.