### PR TITLE
docs(api-docs/material-table): fixed description for MatHeaderRow

### DIFF
--- a/docs-content/api-docs/material-table.html
+++ b/docs-content/api-docs/material-table.html
@@ -1471,7 +1471,7 @@ if there is no difference.</p>
     </a>
   </span>
   
-</h4><p class="docs-api-class-description"><p>Footer template container that contains the cell outlet. Adds the right class and role.</p>
+</h4><p class="docs-api-class-description"><p>Header template container that contains the cell outlet. Adds the right class and role.</p>
 </p><p class="docs-api-directive-selectors">
   <span class="docs-api-class-selector-label">Selector:</span>
   


### PR DESCRIPTION
Issue :
Description under MatHeaderRow extends CdkHeaderRow is

Footer template container that contains the cell outlet. Adds the right class and role.

However it should be,

Header template container that contains the cell outlet. Adds the right class and role.