### PR TITLE
docs(material/autocomplete): update section headers in material autocomplete documentation

### DIFF
--- a/docs-content/api-docs/material-autocomplete.html
+++ b/docs-content/api-docs/material-autocomplete.html
@@ -27,9 +27,9 @@
 
       <div class="docs-api-module-import-button" data-docs-api-module-import-button="import {MatAutocompleteModule} from '@angular/material/autocomplete';"></div>
     </div>
-  <h3 id="material-autocomplete-directives" class="docs-header-link docs-api-h3">
-      <span header-link="directives"></span>
-      Directives
+  <h3 id="material-autocomplete-components" class="docs-header-link docs-api-h3">
+      <span header-link="components"></span>
+      Components
     </h3>
     
       
@@ -338,7 +338,10 @@ interacting or selecting a value, the initial value will be kept.</p>
 
 
 
-
+  <h3 id="material-autocomplete-directives" class="docs-header-link docs-api-h3">
+    <span header-link="directives"></span>
+    Directives
+  </h3>
     
       
 


### PR DESCRIPTION
Currently, `MatAutocomplete` component is displayed under directives which is incorrect. This fix will add clear different sections between Components and Directives.